### PR TITLE
Fix simulator tilt-adapter diagram plotting off the shared canvas center

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
@@ -1004,14 +1004,34 @@ public class SimulatedTiltAdapterVMTests {
     [Test]
     public void Diagram_OffsetRig_DrawsStoredResponseAngleAtItsPhysicalPosition() {
         // Stored screw 1 = 0° (response) is physically at 180° on an m = +1 rig → must draw at the
-        // BOTTOM (cy = 100 − 75·cos180 = 175 → Y = 163), not the top.
+        // BOTTOM (cy = 130 − 75·cos180 = 205 → Y = 193), not the top.
         var options = Configured(screwCount: 3, curvatureSign: 1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
 
         var screw1 = vm.ScrewDiagramItems.Single(i => i.Number == 1);
         Assert.Multiple(() => {
             Assert.That(screw1.AngleDegrees, Is.EqualTo(180.0).Within(1e-9), "physical angle");
-            Assert.That(screw1.Y, Is.EqualTo(163.0).Within(0.5), "canvas-bottom");
+            Assert.That(screw1.Y, Is.EqualTo(193.0).Within(0.5), "canvas-bottom");
+        });
+    }
+
+    [Test]
+    public void Diagram_PlotsAroundTheSharedTemplateCentreAndCarriesScrewNames() {
+        // This panel plots into the wizard's HF_TiltScrewDiagram template, whose canvas is 260×260 with the
+        // crosshair/rectangle centred at (130,130) — TiltScrewDiagramGeometry is the contract. Plotting around
+        // any other centre shifts every screw off the crosshair (the bug this test pins: the panel kept the
+        // template's pre-label 200×200 centre after the canvas grew, displacing all screws 30px up-left).
+        var options = Configured(screwCount: 3, curvatureSign: -1); // m = −1 → stored == physical
+        var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
+
+        var top = vm.ScrewDiagramItems.Single(i => i.Number == 1);      // physical 0° → canvas top
+        var lower = vm.ScrewDiagramItems.Single(i => i.Number == 2);    // physical 120° → lower right
+        Assert.Multiple(() => {
+            Assert.That(top.X, Is.EqualTo(118.0).Within(0.5), "centred on the vertical axis: 130 − circle radius");
+            Assert.That(top.Y, Is.EqualTo(43.0).Within(0.5), "130 − 75 − circle radius");
+            Assert.That(top.Label, Is.EqualTo("Screw 1"), "no real adapter → the generic naming, same as the rows");
+            Assert.That(top.LabelY, Is.LessThan(top.Y), "top-half name sits above its circle");
+            Assert.That(lower.LabelY, Is.GreaterThan(lower.Y + 24.0), "bottom-half name sits below its circle");
         });
     }
 
@@ -1020,13 +1040,13 @@ public class SimulatedTiltAdapterVMTests {
         // Built on m = −1 (σ = −1): stored 0/120/240 == physical; screw 1 at the top.
         var options = Configured(screwCount: 3, curvatureSign: -1);
         var vm = new SimulatedTiltAdapterVM(options, realAdapterOptions: null);
-        Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(13.0).Within(0.5));
+        Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(43.0).Within(0.5));
         Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("120.0°"));
 
         options.SimScrewInwardCurvatureSign = 1; // reinterpret 180° away
 
         Assert.Multiple(() => {
-            Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(163.0).Within(0.5), "screw 1 flips to the bottom");
+            Assert.That(vm.ScrewDiagramItems.Single(i => i.Number == 1).Y, Is.EqualTo(193.0).Within(0.5), "screw 1 flips to the bottom");
             Assert.That(vm.Screw2AngleDisplay, Is.EqualTo("300.0°"), "readouts flip too");
         });
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -1226,10 +1226,23 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             var centers = new (double cx, double cy)[n];
             for (var i = 0; i < n; i++) {
                 var theta = angles[i] * Math.PI / 180.0;
-                var cx = 100 + 75 * Math.Sin(theta);
-                var cy = 100 - 75 * Math.Cos(theta);
+                var cx = TiltScrewDiagramGeometry.Center + TiltScrewDiagramGeometry.ScrewRadius * Math.Sin(theta);
+                var cy = TiltScrewDiagramGeometry.Center - TiltScrewDiagramGeometry.ScrewRadius * Math.Cos(theta);
                 centers[i] = (cx, cy);
-                ScrewDiagramItems.Add(new TiltScrewDiagramItem { X = cx - 12, Y = cy - 12, Number = i + 1, AngleDegrees = angles[i] });
+                // Name placement mirrors the wizard's RebuildDiagram: above the circle in the canvas's top
+                // half, below it in the bottom half, so labels stay clear of the sensor rectangle.
+                var labelY = cy < TiltScrewDiagramGeometry.Center
+                    ? cy - TiltScrewDiagramGeometry.ScrewCircleRadius - TiltScrewDiagramGeometry.LabelHeight
+                    : cy + TiltScrewDiagramGeometry.ScrewCircleRadius + 2;
+                ScrewDiagramItems.Add(new TiltScrewDiagramItem {
+                    X = cx - TiltScrewDiagramGeometry.ScrewCircleRadius,
+                    Y = cy - TiltScrewDiagramGeometry.ScrewCircleRadius,
+                    Number = i + 1,
+                    AngleDegrees = angles[i],
+                    Label = ScrewName(i),
+                    LabelX = cx - TiltScrewDiagramGeometry.LabelWidth / 2.0,
+                    LabelY = labelY
+                });
             }
             for (var i = 0; i < n; i++) {
                 var j = (i + 1) % n;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -681,9 +681,11 @@
     </GeometryGroup>
 
     <!--
-        Diagram canvas shared between Panel A (saved calibration) and Panel C (complete step).
-        Layout: 200×200 canvas, center (100,100).
-          • Sensor rectangle: 90×60 (3:2), centered → (55,70)-(145,130)
+        Diagram canvas shared between Panel A (saved calibration), Panel C (complete step), and the camera
+        simulator's adapter-configuration panel (TiltAdapterDataTemplates.xaml). Layout: 260×260 canvas,
+        center (130,130) — the geometry contract is TiltScrewDiagramGeometry, and every VM that plots
+        ScrewDiagramItems into this template must use those constants.
+          • Sensor rectangle: 90×60 (3:2), centered → (85,100)-(175,160)
           • Sensor-axis crosshair: short dashes (StrokeDashArray="4,4"), opacity 0.5
           • Screw connection polygon: long dashes (StrokeDashArray="10,4"), opacity 0.75
           • Screw circles: radius 75 from center, 24×24 circles

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -4110,14 +4110,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        // Screw-diagram geometry. The XAML canvas (HF_TiltScrewDiagram) is 2 * DiagramCenter on a side and
-        // every fixed coordinate in it is expressed relative to the same centre; changing these means
-        // changing that template to match.
-        private const double DiagramCenter = 130.0;
-        private const double DiagramScrewRadius = 75.0;
-        private const double DiagramScrewCircleRadius = 12.0;
-        private const double DiagramLabelWidth = 64.0;
-        private const double DiagramLabelHeight = 14.0;
+        // Screw-diagram geometry — the shared HF_TiltScrewDiagram contract. The constants live in
+        // TiltScrewDiagramGeometry because the camera simulator's adapter panel plots into the same template.
+        private const double DiagramCenter = TiltScrewDiagramGeometry.Center;
+        private const double DiagramScrewRadius = TiltScrewDiagramGeometry.ScrewRadius;
+        private const double DiagramScrewCircleRadius = TiltScrewDiagramGeometry.ScrewCircleRadius;
+        private const double DiagramLabelWidth = TiltScrewDiagramGeometry.LabelWidth;
+        private const double DiagramLabelHeight = TiltScrewDiagramGeometry.LabelHeight;
 
         private void RebuildDiagram() {
             // RebuildDiagram is the single choke point reached on every calibration, direction, and

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewDiagramItem.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltScrewDiagramItem.cs
@@ -12,6 +12,23 @@
 
 namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
+    /// <summary>
+    /// Geometry of the shared HF_TiltScrewDiagram canvas (TiltAdapterWizard/DataTemplates.xaml). The canvas is
+    /// 2 × <see cref="Center"/> on a side and every fixed coordinate in it — crosshair, sensor rectangle, 0°
+    /// chevron — is expressed relative to that same centre, so every VM that plots
+    /// <see cref="TiltScrewDiagramItem"/>s into it must use THESE constants. Both the wizard and the camera
+    /// simulator's adapter panel render this template; a consumer with its own copy silently drifts off the
+    /// crosshair when the canvas is resized, which is exactly how the simulator's diagram broke when the canvas
+    /// grew for screw names. Changing these means changing the template to match.
+    /// </summary>
+    public static class TiltScrewDiagramGeometry {
+        public const double Center = 130.0;
+        public const double ScrewRadius = 75.0;
+        public const double ScrewCircleRadius = 12.0;
+        public const double LabelWidth = 64.0;
+        public const double LabelHeight = 14.0;
+    }
+
     public class TiltScrewDiagramItem {
         public double X { get; set; }           // Canvas.Left
         public double Y { get; set; }           // Canvas.Top


### PR DESCRIPTION
## Problem

A user screenshot showed the screw diagram on the **tilt adapter simulator configuration page** rendering wrong — the screw circles sit visibly off the crosshair/rectangle center, distorting the apparent screw angles. Both 3- and 4-screw setups are affected.

## Root cause

The screw-labels feature (8c6a272, PR #203) grew the shared `HF_TiltScrewDiagram` canvas from 200×200 to 260×260 and moved the wizard's `RebuildDiagram` to the new (130,130) center — but `SimulatedTiltAdapterVM.RebuildDiagram`, which plots into the **same template**, kept its own hardcoded (100,100) center. Every screw was displaced 30px up-left of the diagram center (verified quantitatively against the user's screenshot: predicted radial distances 133/49/113/167px vs. measured ~136/51/120/174px). The same missed update also left the sim diagram without the screw-name blocks the template gained.

The existing sim tests asserted the stale coordinates (top screw at Y=13), so they passed while the rendering was broken.

## Fix

- Canvas geometry now lives once in `TiltScrewDiagramGeometry` (beside `TiltScrewDiagramItem`); both the wizard VM and the simulator VM consume it, so the two plotting implementations can no longer drift when the canvas changes.
- `SimulatedTiltAdapterVM.RebuildDiagram` plots around the shared center and now populates `Label`/`LabelX`/`LabelY` with the wizard's placement rule, so screw names (e.g. EAT M1/M2/M4/M3) render on the sim diagram too.
- Fixed the template's stale "200×200, center (100,100)" comment and noted the third consumer.

## Tests

- Updated the sim diagram tests to the real template geometry (Y=43/193) and added `Diagram_PlotsAroundTheSharedTemplateCentreAndCarriesScrewNames` pinning the center and label behavior (fails on the old code).
- Full suite: 4437 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mew5eUfnQR9ZQbyfTuigUd